### PR TITLE
Add feedback toasts to recipe addition

### DIFF
--- a/app/src/components/AddRecipeModal.tsx
+++ b/app/src/components/AddRecipeModal.tsx
@@ -8,35 +8,28 @@ import {
   TextField,
 } from "@mui/material";
 import { useState } from "react";
-import { useAtom } from "jotai";
-import { tokenAtom } from "../App";
-import { post } from "../helpers/backendRequests";
 
 interface propTypes {
   modalOpen: boolean;
   setModalOpen: Function;
-  getRecipes: Function;
+  addRecipe: Function;
 }
 
 export function AddRecipeModal({
   modalOpen,
   setModalOpen,
-  getRecipes,
+  addRecipe,
 }: propTypes) {
   const [newRecipeUrl, setNewRecipeUrl] = useState("");
-
-  const [token] = useAtom(tokenAtom);
 
   const handleClose = () => {
     setNewRecipeUrl("");
     setModalOpen(false);
   };
 
-  const addRecipe = async () => {
-    await post("/recipes", { url: newRecipeUrl }, token.access_token);
-
-    getRecipes();
-    handleClose();
+  const addRecipeAndClose = () => {
+    setNewRecipeUrl("");
+    addRecipe(newRecipeUrl);
   };
 
   return (
@@ -59,7 +52,7 @@ export function AddRecipeModal({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Close</Button>
-        <Button onClick={addRecipe}>Add recipe</Button>
+        <Button onClick={addRecipeAndClose}>Add recipe</Button>
       </DialogActions>
     </Dialog>
   );

--- a/app/src/components/RecipeResultSnackBar.tsx
+++ b/app/src/components/RecipeResultSnackBar.tsx
@@ -1,0 +1,27 @@
+import { Alert, Snackbar } from "@mui/material";
+
+interface PropTypes {
+  open: boolean;
+  error: boolean;
+  errorMessage: string;
+  handleClose: () => void;
+}
+
+export function RecipeResultSnackBar(props: PropTypes) {
+  const { open, error, errorMessage, handleClose } = props;
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={5000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+    >
+      {error ? (
+        <Alert severity="error">{errorMessage}</Alert>
+      ) : (
+        <Alert severity="success">Recipe added successfully</Alert>
+      )}
+    </Snackbar>
+  );
+}

--- a/app/src/components/RecipeResultSnackBar.tsx
+++ b/app/src/components/RecipeResultSnackBar.tsx
@@ -1,4 +1,4 @@
-import { Alert, Snackbar } from "@mui/material";
+import { Alert, AlertTitle, Snackbar } from "@mui/material";
 
 interface PropTypes {
   open: boolean;
@@ -17,11 +17,10 @@ export function RecipeResultSnackBar(props: PropTypes) {
       onClose={handleClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
     >
-      {error ? (
-        <Alert severity="error">{errorMessage}</Alert>
-      ) : (
-        <Alert severity="success">Recipe added successfully</Alert>
-      )}
+      <Alert severity={error ? "error" : "success"} onClose={handleClose}>
+        <AlertTitle>{error ? "Error adding recipe" : "Success"}</AlertTitle>
+        {error ? errorMessage : "Recipe added successfully"}
+      </Alert>
     </Snackbar>
   );
 }

--- a/app/src/pages/RecipeDisplayPage.tsx
+++ b/app/src/pages/RecipeDisplayPage.tsx
@@ -17,12 +17,18 @@ import AddIcon from "@mui/icons-material/Add";
 import { rbTheme } from "../styles/styles";
 import MenuAppBar from "../components/MenuAppBar";
 import { tokenAtom } from "../App";
+import { post } from "../helpers/backendRequests";
+import { RecipeResultSnackBar } from "../components/RecipeResultSnackBar";
 
 export function RecipeDisplayPage() {
   const [token] = useAtom(tokenAtom);
 
   const [recipes, setRecipes] = useState<Array<Recipe>>([]);
   const [modalOpen, setModalOpen] = useState(false);
+
+  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
+  const [snackbarIsError, setSnackbarIsError] = useState<boolean>(false);
+  const [snackbarErrorMessage, setSnackbarErrorMessage] = useState<string>("");
 
   const fabStyle = {
     position: "sticky",
@@ -36,8 +42,27 @@ export function RecipeDisplayPage() {
         Authorization: `Bearer ${token.access_token}`,
       },
     });
-
     setRecipes(data);
+  };
+
+  const addRecipe = async (newRecipeUrl: string) => {
+    setModalOpen(false);
+    try {
+      const { data } = await post(
+        "/recipes",
+        { url: newRecipeUrl },
+        token.access_token
+      );
+      console.log(data);
+      getRecipes();
+      setSnackbarIsError(false);
+      setSnackbarOpen(true);
+    } catch (e: any) {
+      console.log(e.response.data.message);
+      setSnackbarErrorMessage(e.response.data.message);
+      setSnackbarIsError(true);
+      setSnackbarOpen(true);
+    }
   };
 
   useEffect(() => {
@@ -61,7 +86,13 @@ export function RecipeDisplayPage() {
           <AddRecipeModal
             modalOpen={modalOpen}
             setModalOpen={setModalOpen}
-            getRecipes={getRecipes}
+            addRecipe={addRecipe}
+          />
+          <RecipeResultSnackBar
+            open={snackbarOpen}
+            error={snackbarIsError}
+            errorMessage={snackbarErrorMessage}
+            handleClose={() => setSnackbarOpen(false)}
           />
           <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
             <Stack spacing={2}>
@@ -82,7 +113,3 @@ export function RecipeDisplayPage() {
     </ThemeProvider>
   );
 }
-
-// interface propTypes {
-//   tokenAtom: Atom<any>;
-// }

--- a/app/src/pages/RecipeDisplayPage.tsx
+++ b/app/src/pages/RecipeDisplayPage.tsx
@@ -48,17 +48,11 @@ export function RecipeDisplayPage() {
   const addRecipe = async (newRecipeUrl: string) => {
     setModalOpen(false);
     try {
-      const { data } = await post(
-        "/recipes",
-        { url: newRecipeUrl },
-        token.access_token
-      );
-      console.log(data);
+      await post("/recipes", { url: newRecipeUrl }, token.access_token);
       getRecipes();
       setSnackbarIsError(false);
       setSnackbarOpen(true);
     } catch (e: any) {
-      console.log(e.response.data.message);
       setSnackbarErrorMessage(e.response.data.message);
       setSnackbarIsError(true);
       setSnackbarOpen(true);


### PR DESCRIPTION
When recipes are added to the database, there is now a feedback toast which confirms whether the addition was successful or failed in some way. If the addition failed, the toast will contain the error message passed through from the backend.

This PR resolves #5