### PR TITLE
Validation on Grocy API Settings

### DIFF
--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -152,12 +152,14 @@ export function SettingsPage() {
                       value={grocyBaseUrl}
                       onChange={(e) => setGrocyBaseUrl(e.target.value)}
                       margin="dense"
+                      required
                     />
                     <TextField
                       label="Grocy API Key"
                       value={grocyApiKey}
                       onChange={(e) => setGrocyApiKey(e.target.value)}
                       margin="dense"
+                      required
                     />
                     <Button onClick={updateSettings}>Update</Button>
                     {grocySettingsCorrect

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -153,6 +153,7 @@ export function SettingsPage() {
                       onChange={(e) => setGrocyBaseUrl(e.target.value)}
                       margin="dense"
                       required
+                      type="url"
                     />
                     <TextField
                       label="Grocy API Key"

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -162,7 +162,12 @@ export function SettingsPage() {
                       margin="dense"
                       required
                     />
-                    <Button onClick={updateSettings}>Update</Button>
+                    <Button
+                      onClick={updateSettings}
+                      disabled={grocyBaseUrl === "" || grocyApiKey === ""}
+                    >
+                      Update
+                    </Button>
                     {grocySettingsCorrect
                       ? "Connected to Grocy"
                       : "Cannot connect to Grocy"}


### PR DESCRIPTION
This PR resolves #21 

The Grocy settings page will now validate whether the boxes are filled in before allowing the update button to be clicked

The boxes are both required and the URL one is now of input type URL