### PR TITLE
recipe-buddy-20 Redirect to login page after initial setup

### DIFF
--- a/app/src/pages/SetupPage.tsx
+++ b/app/src/pages/SetupPage.tsx
@@ -28,7 +28,7 @@ export function SetupPage() {
         password: password,
       });
       console.log(data);
-      navigate("/recipes");
+      navigate("/");
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
This PR resolves #20 

On initial setup the user is now redirected to the login screen rather than the recipe screen. They then log in with the newly created credentials and the situation of being semi-logged-in is avoided. 