### PR TITLE
fix: read unreadable ingredients and steps when they are split into sub arrays

### DIFF
--- a/api/src/recipes/scraper/recipeScraper.ts
+++ b/api/src/recipes/scraper/recipeScraper.ts
@@ -5,7 +5,7 @@ import { Recipe } from '../schemas/recipe.schema';
 @Injectable()
 export class RecipeScraper {
   parseRecipeSteps(steps) {
-    return steps.map((step) => {
+    return steps.flat().map((step) => {
       if (typeof step === 'string') return step.trim();
       if (step.hasOwnProperty('text')) return step.text.trim();
       throw new Error('Unable to parse recipe steps');
@@ -20,7 +20,7 @@ export class RecipeScraper {
   }
 
   parseRecipeIngredients = (ingredients) => {
-    return ingredients.map((ingredient) => ingredient.trim());
+    return ingredients.flat().map((ingredient) => ingredient.trim());
   };
 
   parseRecipeName = (name) => {


### PR DESCRIPTION
Flattened the list of steps and ingredients in case they are further split into sub arrays (Encountered on yemek.com)

Fixes #250