### PR TITLE
build: reduce the file size of backend docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,11 +1,21 @@
-FROM node:16-alpine
+FROM node:16-alpine AS builder
+
+WORKDIR /root/
 
 COPY . .
 
-RUN npm install
+RUN yarn install --frozen-lockfile
 
-RUN npm run build
+RUN yarn build
+
+
+FROM node:16-alpine
+
+WORKDIR /root/
+
+COPY --from=builder /root/node_modules /root/node_modules
+COPY --from=builder /root/dist /root/dist
 
 EXPOSE 4000
 
-CMD ["npm", "run", "start:prod"]
+CMD ["node", "dist/main"]


### PR DESCRIPTION
Reduced the size backend docker image by employing multi-stage build on it's dockerfile.

A before and after comparison:
![docker-size-diff](https://user-images.githubusercontent.com/17270595/206281276-fec9e3f4-00a7-4203-aab3-ec8665d30dd7.png)


aims to alleviate #252 