### PR TITLE
added support for more websites, a new formatting and some fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:18-alpine AS base
 
 # mostly inspired from https://github.com/BretFisher/node-docker-good-defaults/blob/main/Dockerfile & https://github.com/remix-run/example-trellix/blob/main/Dockerfile
 
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+# Check https://github.com/nodejs/docker-node/blob/7c659dfc7bd632725695aa2112eb0cf0e5357cfd/README.md#nodealpine to understand why gcompat might be needed.
+RUN apk add --no-cache gcompat
 RUN corepack enable && corepack prepare pnpm@8.15.5 --activate
 # set the store dir to a folder that is not in the project
 RUN pnpm config set store-dir ~/.pnpm-store
@@ -44,7 +44,7 @@ WORKDIR /home/node/app
 
 RUN apk add --no-cache dumb-init
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 ENV DATABASE_URL="/home/node/app/data/sqlite.db"
 
 RUN mkdir data
@@ -74,9 +74,9 @@ RUN npx tsc -b ./migrations
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV HOSTNAME 0.0.0.0
-ENV NEXTAUTH_URL_INTERNAL http://0.0.0.0:3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+ENV NEXTAUTH_URL_INTERNAL=http://0.0.0.0:3000
 
 RUN chmod +x ./run.sh
 

--- a/src/server/api/modules/recipes/service/schemas.ts
+++ b/src/server/api/modules/recipes/service/schemas.ts
@@ -1,26 +1,28 @@
 import z from "zod"
 
-type Step = {
-  "@context": string;
-  "@type": string;
-  text: string;
-};
+const StepSchema = z.object({
+  "@context": z.string(),
+  "@type": z.string(),
+  text: z.string(),
+})
 
-function beautifyInstructions(input: string): string {
-  const sections = input.split(/\n\n+/);
-  
+const beautifyInstructions = (input: string): string => {
+  const sections = input.split(/\n\n+/)
+
   const formattedSections = sections.map((section, index) => {
-      const numberedSection = section.replace(/\n/g, '<br>');
-      return `${index + 1}. ${numberedSection}`;
-  });
+    const numberedSection = section.replace(/\n/g, "<br>")
+    return `${index + 1}. ${numberedSection}`
+  })
 
-  return formattedSections.map(section => `<p>${section}</p>`).join('');
+  return formattedSections.map((section) => `<p>${section}</p>`).join("")
 }
 
-export function StepsSchema(steps: string | Step[]){
-  if (typeof steps === "string") return beautifyInstructions(steps);
-  return beautifyInstructions(steps.map(step => step.text).join('\n\n')); 
-}
+export const StepsToStringSchema = z
+  .union([z.array(StepSchema), z.string()])
+  .transform((steps) => {
+    if (typeof steps === "string") return beautifyInstructions(steps)
+    return beautifyInstructions(steps.map((step) => step.text).join("\n\n"))
+  })
 
 const baseUrlSchema = z.union([z.string(), z.object({ url: z.string() })])
 export const RecipeImageUrlSchema = z

--- a/src/server/api/modules/recipes/service/schemas.ts
+++ b/src/server/api/modules/recipes/service/schemas.ts
@@ -1,11 +1,26 @@
 import z from "zod"
 
-export const RecipeStepSchema = z
-  .union([z.string(), z.object({ text: z.string() })])
-  .transform((input): string => {
-    if (typeof input === "string") return input
-    return input.text
-  })
+type Step = {
+  "@context": string;
+  "@type": string;
+  text: string;
+};
+
+function beautifyInstructions(input: string): string {
+  const sections = input.split(/\n\n+/);
+  
+  const formattedSections = sections.map((section, index) => {
+      const numberedSection = section.replace(/\n/g, '<br>');
+      return `${index + 1}. ${numberedSection}`;
+  });
+
+  return formattedSections.map(section => `<p>${section}</p>`).join('');
+}
+
+export function StepsSchema(steps: string | Step[]){
+  if (typeof steps === "string") return beautifyInstructions(steps);
+  return beautifyInstructions(steps.map(step => step.text).join('\n\n')); 
+}
 
 const baseUrlSchema = z.union([z.string(), z.object({ url: z.string() })])
 export const RecipeImageUrlSchema = z

--- a/src/server/api/modules/recipes/service/scraper.ts
+++ b/src/server/api/modules/recipes/service/scraper.ts
@@ -40,14 +40,30 @@ function jsonObjectHasGraph(jsonObject: Record<string, unknown>): boolean {
   return Object.prototype.hasOwnProperty.call(jsonObject, "@graph")
 }
 
+function normalizeWhitespace(input: string): string {
+  return input.replace(/[\u00A0\u1680\u180E\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]/g, ' ');
+}
+
+function escapeRealLineBreaksInString(input: string): string {
+  return input.replace(/(["'])([\s\S]*?)\1/g, (match, quote, content) => {
+    const escapedContent = content.replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+    return quote + escapedContent + quote;
+  });
+}
+
+
 function getSchemaRecipeFromNodeList(nodeList: NodeList) {
   for (const node of nodeList.values()) {
-    const { textContent } = node
+    let { textContent } = node
 
     if (!textContent) {
       logger.debug("No text content in node, trying next node")
       continue
     }
+
+    // Preprocess the text to ensure that it can be parsed as JSON
+    textContent = escapeRealLineBreaksInString(textContent);
+    textContent = normalizeWhitespace(textContent);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let parsedNodeContent: any


### PR DESCRIPTION
This MR adds scraping support for websites which store the `recipeInstructions` as a string and not as an array of objects.

This includes `chefkoch.de` and therefore closes  #278 and closes #498

---

Also included is a minor additional formatting of the Steps including paragraphs and numbering:

![image](https://github.com/user-attachments/assets/74cb584c-e2b5-41b5-856d-00511192fd72)

---

Additionally, there the usage of `libc6-compat` in the Dockerfile lead to a build error since the package does not exist anymore for alpine and is now replaced with the successor `gcompat`. I also changed the deprecated format in the Dockerfile causing warnings.

---

Furthermore, I added a preprocessing for malformed JSON input including real newlines instead of `\n` and different kinds of white-spaces causing issues for some recipes from `lidl-kochen.de`.